### PR TITLE
removed former MVP

### DIFF
--- a/Office Apps and Services-ids.txt
+++ b/Office Apps and Services-ids.txt
@@ -184,7 +184,6 @@ jseghers
 judecper
 JussiMori
 jussiroine
-justimorris
 jwillie
 KamilBaczyk
 KamilJurik


### PR DESCRIPTION
Justin Morris is no longer a MVP