### PR TITLE
Delete Access-ids.txt

### DIFF
--- a/Access-ids.txt
+++ b/Access-ids.txt
@@ -1,8 +1,0 @@
-AccessWisdom
-itsdbguy
-jhshirley
-JimDettman_OCS
-JulianKirkness
-LukeChung
-smartaccess
-SudburyTraining


### PR DESCRIPTION
This list shouldn't exist any longer, as it has been replaced with the consolidated Office Apps and Services category.