### PR TITLE
Delete OneNote-ids.txt

### DIFF
--- a/OneNote-ids.txt
+++ b/OneNote-ids.txt
@@ -1,7 +1,0 @@
-haukeberg
-HuqiangDing
-kramkr
-mparlakyigit
-oh365eh_kelly
-OneNoteC
-twiiter.comStefanMalter


### PR DESCRIPTION
This list shouldn't exist any longer, as it has been replaced with the consolidated Office Apps and Services category.