### PR TITLE
Delete Outlook-ids.txt

### DIFF
--- a/Outlook-ids.txt
+++ b/Outlook-ids.txt
@@ -1,7 +1,0 @@
-contactgenie
-cortig
-elegault
-outlooktips
-palelmvp
-RobertSparnaaij
-TVWizard


### PR DESCRIPTION
This list shouldn't exist any longer, as it has been replaced with the consolidated Office Apps and Services category.